### PR TITLE
emit events when receiving messages on the `urlShareStart` and `urlShareStop` channels

### DIFF
--- a/src/simplewebrtc.js
+++ b/src/simplewebrtc.js
@@ -236,8 +236,12 @@ function SimpleWebRTC(opts) {
     });
 
     this.webrtc.on('channelMessage', function (peer, label, data) {
-        if (data.type == 'volume') {
+        if (data.type === 'volume') {
             self.emit('remoteVolumeChange', peer, data.volume);
+        } else if (data.type === 'urlShareStart') {
+            self.emit('urlShareStart', peer, data.payload);
+        } else if (data.type === 'urlShareStop') {
+            self.emit('urlShareStop', peer, data.payload);
         }
     });
 


### PR DESCRIPTION
To support url sharing on the riff client, we want to emit events whenever we receive a message through the data channels that correspond to url sharing stop & start events. This allows us to register listeners on the client without having to actively monitor the data channels themselves. 